### PR TITLE
Fix package building process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.2
+        with:
+          # Set always-auth in npmrc
+          node-version: '12'
+          registry-url: 'https://registry.npmjs.org'
+        
       - name: Publish to npmjs
         run: |
           npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,8 +42,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to npmjs
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_APIKEY }}
-          package: projects/@crucible-common/package.json
-          access: public
+        run: |
+          npm install
+          npm run pack
+          find . -name "*.tgz"
+          npm publish dist/@crucible-common/cmusei-crucible-common-0.0.3.tgz --access public --dry-run
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_APIKEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,3 +48,4 @@ jobs:
           npm publish dist/@crucible-common/cmusei-crucible-common-${{ github.event.inputs.version }}.tgz --access public
         env:
           NPM_TOKEN: ${{ secrets.NPM_APIKEY }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_APIKEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,6 @@ jobs:
         run: |
           npm install
           npm run pack
-          find . -name "*.tgz"
           npm publish dist/@crucible-common/cmusei-crucible-common-${{ github.event.inputs.version }}.tgz --access public --dry-run
         env:
           NPM_TOKEN: ${{ secrets.NPM_APIKEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,6 @@ jobs:
           npm install
           npm run pack
           find . -name "*.tgz"
-          npm publish dist/@crucible-common/cmusei-crucible-common-0.0.3.tgz --access public --dry-run
+          npm publish dist/@crucible-common/cmusei-crucible-common-${{ github.event.inputs.version }}.tgz --access public --dry-run
         env:
           NPM_TOKEN: ${{ secrets.NPM_APIKEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,6 @@ jobs:
         run: |
           npm install
           npm run pack
-          npm publish dist/@crucible-common/cmusei-crucible-common-${{ github.event.inputs.version }}.tgz --access public --dry-run
+          npm publish dist/@crucible-common/cmusei-crucible-common-${{ github.event.inputs.version }}.tgz --access public
         env:
           NPM_TOKEN: ${{ secrets.NPM_APIKEY }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+@cmusei:registry=https://registry.npmjs.org/@cmusei

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-registry=https://registry.npmjs.org/
-@cmusei:registry=https://registry.npmjs.org/@cmusei

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cwd-common-app",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cwd-common-app",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cwd-common-app",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cwd-common-app",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/projects/@crucible-common/package-lock.json
+++ b/projects/@crucible-common/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@cmusei/crucible-common",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1
 }

--- a/projects/@crucible-common/package-lock.json
+++ b/projects/@crucible-common/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@cmusei/crucible-common",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1
 }

--- a/projects/@crucible-common/package.json
+++ b/projects/@crucible-common/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@cmusei/crucible-common",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "MIT",
   "description": "A set of angular modules that are common between Crucible apps",
   "repository": {
-      "type": "git",
-      "url": "https://github.com/cmu-sei/Crucible.Common.Ui.git"
+    "type": "git",
+    "url": "https://github.com/cmu-sei/Crucible.Common.Ui.git"
   },
   "peerDependencies": {
     "@angular/common": "^8.2.14",

--- a/projects/@crucible-common/package.json
+++ b/projects/@crucible-common/package.json
@@ -14,5 +14,15 @@
     "oidc-client": "^1.10.1",
     "rxjs": "~6.5.5"
   },
-  "dependencies": {}
+  "dependencies": {
+    "tslib": "^1.10.0"
+  },
+  "main": "bundles/crucible-common.umd.js",
+  "module": "fesm5/crucible-common.js",
+  "es2015": "fesm2015/crucible-common.js",
+  "esm5": "esm5/crucible-common.js",
+  "esm2015": "esm2015/crucible-common.js",
+  "fesm5": "fesm5/crucible-common.js",
+  "fesm2015": "fesm2015/crucible-common.js",
+  "typings": "crucible-common.d.ts"
 }

--- a/projects/@crucible-common/package.json
+++ b/projects/@crucible-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmusei/crucible-common",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "MIT",
   "description": "A set of angular modules that are common between Crucible apps",
   "repository": {


### PR DESCRIPTION
The package was not being built properly before.  This PR fixes the build and push to npmjs.

It also bumps the version up to 0.0.5 since 0.0.4 was published in an incorrect format.