### PR TITLE
switched to rimraf for cross-platform 'rm -rf' in npm scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1767,6 +1767,11 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
+    },
     "@hapi/formula": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
@@ -1778,6 +1783,37 @@
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
       "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==",
       "dev": true
+    },
+    "@hapi/joi": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/topo": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/address": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+          "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
+        },
+        "@hapi/hoek": {
+          "version": "8.5.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+          "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
+        },
+        "@hapi/topo": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+          "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+          "requires": {
+            "@hapi/hoek": "^8.3.0"
+          }
+        }
+      }
     },
     "@hapi/pinpoint": {
       "version": "2.0.0",
@@ -9563,7 +9599,22 @@
         "find-process": "^1.4.3",
         "prompts": "^2.3.0",
         "spawnd": "^4.4.0",
-        "tree-kill": "^1.2.2"
+        "tree-kill": "^1.2.2",
+        "wait-on": "^3.3.0"
+      },
+      "dependencies": {
+        "wait-on": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-3.3.0.tgz",
+          "integrity": "sha512-97dEuUapx4+Y12aknWZn7D25kkjMk16PbWoYzpSdA8bYpVfS6hpl2a2pOWZ3c+Tyt3/i4/pglyZctG3J4V1hWQ==",
+          "requires": {
+            "@hapi/joi": "^15.0.3",
+            "core-js": "^2.6.5",
+            "minimist": "^1.2.0",
+            "request": "^2.88.0",
+            "rx": "^4.1.0"
+          }
+        }
       }
     },
     "jest-diff": {
@@ -14934,6 +14985,11 @@
       "requires": {
         "aproba": "^1.1.1"
       }
+    },
+    "rx": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
     },
     "rxjs": {
       "version": "6.5.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "watch:crucible-common": "ng build crucible-common --watch",
     "link:crucible-common": "wait-on dist/@crucible-common/package.json && npm link dist/@crucible-common",
     "pack": "npm run build crucible-common --aot && cd dist/@crucible-common && npm pack",
-    "build:clean": "rm -rf dist",
+    "build:clean": "rimraf dist",
     "build:link": "npm run build:clean && run-p watch:* link:crucible-common ",
     "json-server": "json-server ./projects/cwd-common-app/src/assets/db/db.json",
     "playground": "angular-playground"
@@ -64,6 +64,7 @@
     "ng-packagr": "^9.0.0",
     "npm-run-all": "^4.1.5",
     "protractor": "~7.0.0",
+    "rimraf": "^3.0.2",
     "ts-node": "~8.10.2",
     "tslint": "~6.1.2",
     "typescript": "3.8.3",


### PR DESCRIPTION
fixes error when attempting 'rm -rf' in clean script on Windows