### PR TITLE
fix duplicate settings calls

### DIFF
--- a/projects/@crucible-common/src/lib/comn-settings/comn-settings.module.ts
+++ b/projects/@crucible-common/src/lib/comn-settings/comn-settings.module.ts
@@ -21,13 +21,7 @@ export function get_settings(settings: ComnSettingsService) {
 export const COMN_SETTINGS_TOKEN = new InjectionToken('ComnSettings');
 
 @NgModule({ declarations: [],
-    exports: [], imports: [CommonModule], providers: [
-        provideAppInitializer(() => {
-        const initializerFn = (get_settings)(inject(ComnSettingsService));
-        return initializerFn();
-      }),
-        provideHttpClient(withInterceptorsFromDi()),
-    ] })
+    exports: [], imports: [CommonModule], providers: [] })
 export class ComnSettingsModule {
   constructor(@Optional() @SkipSelf() parentModule: ComnSettingsModule) {
     if (parentModule) {
@@ -48,6 +42,7 @@ export class ComnSettingsModule {
         const initializerFn = (get_settings)(inject(ComnSettingsService));
         return initializerFn();
       }),
+        provideHttpClient(withInterceptorsFromDi()),
         { provide: COMN_SETTINGS_CONFIG, useValue: config },
       ],
     };


### PR DESCRIPTION
ComnSettingsService was being initialized twice, causing each settings.*.json file to be retrieved twice by the browser on every page load. Removed duplicate appInitalizer registration, keeping only the one in forRoot.