### PR TITLE
Remove signinSilent from auth guard to fix blank page on first load

### DIFF
--- a/projects/@crucible-common/src/lib/comn-auth/services/comn-auth-guard.service.ts
+++ b/projects/@crucible-common/src/lib/comn-auth/services/comn-auth-guard.service.ts
@@ -15,18 +15,7 @@ export class ComnAuthGuardService implements CanActivate {
       if (isAuthenticated) {
         return true;
       } else {
-        return this.authService
-          .startSilentAuthentication()
-          .then((user) => {
-            if (user && !user.expired) {
-              return true;
-            } else {
-              return this.startAuthentication(state.url);
-            }
-          })
-          .catch((e) => {
-            return this.startAuthentication(state.url);
-          });
+        return this.startAuthentication(state.url);
       }
     });
   }


### PR DESCRIPTION
**Summary**
                                                                                                                    
  - Remove signinSilent() call from ComnAuthGuardService.canActivate() to eliminate a 10-second blank white page on 
  first visit to any consuming app                      
                                                                                                                    
  **Problem**
   
  When an unauthenticated user visits a consuming app, the auth guard calls signinSilent() before falling back to   
  signinRedirect(). This opens a hidden iframe to Keycloak — but when there's no existing IDP session (first visit,
  cleared cookies, etc.), the iframe loads Keycloak's login page and can never complete silently. It hangs for the  
  full oidc-client-ts default timeout of 10 seconds before the guard finally falls through to signinRedirect().
  During this wait, the user sees a blank white page with no feedback.

  **Fix**
   
  Skip signinSilent() in the guard entirely. If isAuthenticated() returns false, go straight to signinRedirect().   
                                                        
  This is safe because:                                                                                             
  - automaticSilentRenew (configured in each consuming app's settings) already handles proactive background token
  renewal before expiry — that's independent of the guard                                                           
  - If a user returns with an expired token but a valid Keycloak SSO session, signinRedirect() sends them to
  Keycloak which recognizes the session and redirects back immediately (~200-500ms) with no login prompt            
  - If the SSO session is also gone, signinSilent() would have failed anyway after the 10-second wait               
  - startSilentAuthentication() remains available on ComnAuthService for any consuming app that calls it directly —
  no breaking API change                                                                                            
                                                                                                                    
  **Test plan**
                                                                                                                    
  - First visit (no IDP session): Open app in incognito — should redirect to Keycloak login instantly, no blank page
  - Returning visit (expired token, valid IDP session): Clear app storage but keep Keycloak session — should        
  redirect through Keycloak and back immediately without login prompt                                               
  - Already authenticated: Guard resolves immediately, no change in behavior
  - Cross-app SSO: Log into one app, then visit another — should redirect through Keycloak and back within ~500ms   
  - Token renewal while active: Verify automaticSilentRenew still refreshes tokens in the background before expiry