### PR TITLE
Fix Enter-to-submit in crucible-dialog form modals

### DIFF
--- a/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.html
+++ b/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.html
@@ -12,8 +12,16 @@
 
 @if (form(); as fg) {
   <!-- Branch A: form modal. The single <form> wraps content AND actions so
-       type="submit" and Enter-to-submit work (§2b). -->
-  <form [formGroup]="fg" (ngSubmit)="onFormSubmit($event)">
+       type="submit" and Enter-to-submit work (§2b). The explicit (keydown.enter)
+       handler guarantees Enter submits even when a host app's global key handler
+       (e.g. @ngneat/hotkeys with a default "enter" shortcut + allowIn:["INPUT"])
+       calls preventDefault() and suppresses the browser's native implicit
+       submission. See onEnterKeydown. -->
+  <form
+    [formGroup]="fg"
+    (ngSubmit)="onFormSubmit($event)"
+    (keydown.enter)="onEnterKeydown($event)"
+  >
     <ng-container [ngTemplateOutlet]="contentTpl"></ng-container>
     <ng-container [ngTemplateOutlet]="actionsTpl"></ng-container>
   </form>

--- a/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.spec.ts
+++ b/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.spec.ts
@@ -42,6 +42,7 @@ class MatDialogRefStub {
     >
       <ng-container crucibleDialogContent [formGroup]="form">
         <input id="name-field" formControlName="name" />
+        <textarea id="notes-field" formControlName="notes"></textarea>
       </ng-container>
     </crucible-dialog>
   `,
@@ -51,7 +52,10 @@ class FormHostComponent {
     @ViewChild(CrucibleDialogComponent)
     dialog!: CrucibleDialogComponent;
     title = 'Edit Directory';
-    form = new FormGroup({ name: new FormControl('', Validators.required) });
+    form = new FormGroup({
+        name: new FormControl('', Validators.required),
+        notes: new FormControl(''),
+    });
     submitLabel = 'Save';
     // Signals so that mutating them in a zoneless test schedules change
     // detection, which `await fixture.whenStable()` then flushes.
@@ -236,6 +240,54 @@ describe('CrucibleDialogComponent', () => {
             form.dispatchEvent(new Event('submit'));
             await fixture.whenStable();
             expect(host.submitted).toBe(1);
+        });
+
+        it('submits when Enter is pressed in a text input, even if a host cancels the default action', async () => {
+            // A consuming app may register a global keydown handler that calls
+            // preventDefault() on Enter (e.g. @ngneat/hotkeys with a default
+            // "enter" shortcut and allowIn:["INPUT"]), which suppresses the
+            // browser's native implicit form submission. The dialog must submit
+            // on Enter regardless, so form modals are operable by keyboard (§7).
+            const input: HTMLInputElement = fixture.nativeElement.querySelector('#name-field');
+            const event = new KeyboardEvent('keydown', {
+                key: 'Enter',
+                bubbles: true,
+                cancelable: true,
+            });
+            // Simulate the host having already cancelled the default action.
+            event.preventDefault();
+            input.dispatchEvent(event);
+            await fixture.whenStable();
+            expect(host.submitted).toBe(1);
+        });
+
+        it('emits submit exactly once on Enter (no double-fire with native submit)', async () => {
+            const input: HTMLInputElement = fixture.nativeElement.querySelector('#name-field');
+            input.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+            );
+            await fixture.whenStable();
+            expect(host.submitted).toBe(1);
+        });
+
+        it('does NOT submit on Enter from a textarea (preserves newline entry)', async () => {
+            const textarea: HTMLTextAreaElement = fixture.nativeElement.querySelector('#notes-field');
+            textarea.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+            );
+            await fixture.whenStable();
+            expect(host.submitted).toBe(0);
+        });
+
+        it('does NOT submit on Enter while the primary is disabled', async () => {
+            host.submitDisabled.set(true);
+            await fixture.whenStable();
+            const input: HTMLInputElement = fixture.nativeElement.querySelector('#name-field');
+            input.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+            );
+            await fixture.whenStable();
+            expect(host.submitted).toBe(0);
         });
 
         it('emits submit exactly once when the type="submit" primary is clicked (no double-fire)', async () => {

--- a/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.ts
+++ b/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.ts
@@ -130,6 +130,33 @@ export class CrucibleDialogComponent {
     return !this.hideDefaultActions() && !this.projectedActions;
   }
 
+  onEnterKeydown(event: Event): void {
+    const keyEvent = event as KeyboardEvent;
+    // Mirror native implicit submission: Enter in a multiline control inserts a
+    // newline, it does not submit. Only single-line inputs submit on Enter.
+    const target = keyEvent.target as HTMLElement | null;
+    if (target?.tagName === 'TEXTAREA') {
+      return;
+    }
+    // A host app's global key handler may register an "enter" shortcut that
+    // calls preventDefault() on the keydown (e.g. @ngneat/hotkeys with
+    // allowIn:["INPUT"]), which suppresses the browser's native implicit form
+    // submission. The dialog's own form-level handler runs first (bubbling from
+    // the focused control), so we drive submission ourselves rather than relying
+    // on the default action surviving. preventDefault here also stops a second,
+    // native submit from firing — submit emits exactly once.
+    keyEvent.preventDefault();
+    // Respect the disabled primary: Enter must not submit what the button can't.
+    if (this.primaryDisabled) {
+      return;
+    }
+    // Route through the real form submission pipeline (runs validation and fires
+    // (ngSubmit) → onFormSubmit) rather than emitting submit directly, so Enter
+    // and clicking the primary behave identically.
+    const form = (event.currentTarget ?? event.target) as HTMLFormElement | null;
+    form?.requestSubmit?.();
+  }
+
   onFormSubmit(event: Event): void {
     // Form mode: the projected form's (ngSubmit) is the single submit signal.
     // The native DOM 'submit' event bubbles up to the host <crucible-dialog>,


### PR DESCRIPTION
## Problem

Pressing **Enter** in a `crucible-dialog` form modal did not submit the form, even though the form branch is structurally correct (a single `<form>` wrapping content + actions with a `type="submit"` primary, per design-spec §2b).

## Root cause

The dialog relied on the browser's **native implicit form submission** for Enter. A consuming app's global keydown handler can defeat this. Caster registers an `@ngneat/hotkeys` `ENTER` shortcut (`settings.json` Hotkeys, `allowIn: ["INPUT"]`, library default `preventDefault: true`). Its document-level handler calls `e.preventDefault()` on **every** Enter keydown while an input is focused, suppressing native submission for every form in the app — so the dialog never submitted on Enter.

Diagnosed live by patching `Event.prototype.preventDefault` in the page to capture a stack trace on the Enter keydown, which pointed straight at the `@ngneat/hotkeys` handler.

## Fix

Add an explicit `(keydown.enter)="onEnterKeydown($event)"` handler on the form branch that:
- skips `TEXTAREA` targets (preserves newline entry, mirroring native behavior),
- always `preventDefault()`s (works whether or not a host cancels the default; prevents any double-submit),
- respects `primaryDisabled`,
- routes through `form.requestSubmit()` so the real `(ngSubmit)` → validation → `submit` pipeline runs **exactly once** — Enter and clicking the primary behave identically.

This closes the previously-documented "ngModel/form modals lose native Enter-to-submit" gap. Content (no-form) modals are unchanged.

## Testing

- New unit tests: submit-despite-cancelled-default, exactly-once, textarea-no-submit, disabled-no-submit. Full lib suite **49/49 pass**.
- Verified live in the running Caster **Create New Project** modal: typing a name + Enter now creates the project and navigates to it (previously the dialog stayed open).