### PR TITLE
Support single-button confirm/message dialogs

### DIFF
--- a/projects/@crucible-common/src/lib/crucible-dialog/README.md
+++ b/projects/@crucible-common/src/lib/crucible-dialog/README.md
@@ -55,6 +55,17 @@ this.crucibleDialog
 A confirm that needs an embedded control (e.g. a checkbox) or a non-boolean
 result is really a **form modal** — use `<crucible-dialog>`, not `confirm()`.
 
+### Single-button (message) dialogs
+
+For an acknowledge-only message ("Cannot delete — destroy resources first"),
+pass an empty string for the button you don't want. An empty label hides that
+button, leaving one:
+
+```ts
+// OK-only info dialog (no cancel button):
+this.crucibleDialog.confirm({ title: 'Cannot Delete', message: '…', confirmText: 'OK', cancelText: '' });
+```
+
 ## Reactive form modal
 
 ```html

--- a/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-confirm-dialog/crucible-confirm-dialog.component.html
+++ b/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-confirm-dialog/crucible-confirm-dialog.component.html
@@ -8,8 +8,14 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
-  <button matButton="outlined" [mat-dialog-close]="false">{{ data.cancelText }}</button>
-  <button matButton="filled" [mat-dialog-close]="true" cdkFocusInitial>
-    {{ data.confirmText }}
-  </button>
+  <!-- An empty label hides the button, so a message dialog can show a single
+       acknowledge button (e.g. OK) without a spurious blank-labelled sibling. -->
+  @if (data.cancelText) {
+    <button matButton="outlined" [mat-dialog-close]="false">{{ data.cancelText }}</button>
+  }
+  @if (data.confirmText) {
+    <button matButton="filled" [mat-dialog-close]="true" cdkFocusInitial>
+      {{ data.confirmText }}
+    </button>
+  }
 </mat-dialog-actions>

--- a/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-confirm-dialog/crucible-confirm-dialog.component.spec.ts
+++ b/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-confirm-dialog/crucible-confirm-dialog.component.spec.ts
@@ -82,6 +82,20 @@ describe('CrucibleConfirmDialogComponent', () => {
         expect(ref.closed).toBe(false);
     });
 
+    it('hides the cancel button when cancelText is empty (single affirmative button)', () => {
+        const { fixture } = setup({ confirmText: 'OK', cancelText: '' });
+        const buttons = fixture.nativeElement.querySelectorAll('mat-dialog-actions button');
+        expect(buttons.length).toBe(1);
+        expect(buttons[0].textContent?.trim()).toBe('OK');
+    });
+
+    it('hides the affirmative button when confirmText is empty (single dismiss button)', () => {
+        const { fixture } = setup({ confirmText: '', cancelText: 'Ok' });
+        const buttons = fixture.nativeElement.querySelectorAll('mat-dialog-actions button');
+        expect(buttons.length).toBe(1);
+        expect(buttons[0].textContent?.trim()).toBe('Ok');
+    });
+
     it('renders no error region or spinner (pure static skin)', () => {
         const { fixture } = setup({});
         expect(fixture.nativeElement.querySelector('[role="alert"]')).toBeNull();

--- a/projects/@crucible-common/src/lib/crucible-dialog/models/crucible-confirm-options.ts
+++ b/projects/@crucible-common/src/lib/crucible-dialog/models/crucible-confirm-options.ts
@@ -9,9 +9,17 @@ export interface CrucibleConfirmOptions {
   title: string;
   /** Message body. */
   message: string;
-  /** Affirmative button label. Title Case verb. Default 'Yes'. */
+  /**
+   * Affirmative button label. Title Case verb. Default 'Yes'.
+   * Pass an empty string to render a message dialog with no affirmative button
+   * (e.g. an acknowledge-only "OK" info dialog that uses `cancelText` instead).
+   */
   confirmText?: string;
-  /** Dismiss button label. Title Case. Default 'No'. */
+  /**
+   * Dismiss button label. Title Case. Default 'No'.
+   * Pass an empty string to render a single-button (affirmative-only) dialog,
+   * e.g. an informational "Cannot delete…" message with just an OK button.
+   */
   cancelText?: string;
   /** Forwarded to MatDialog.open config. */
   width?: string;


### PR DESCRIPTION
## Summary

`CrucibleConfirmDialogComponent` always rendered **both** the cancel and confirm buttons. That works for a Yes/No confirm, but an acknowledge-only message dialog (e.g. "Cannot delete — destroy the resources first") had no way to show a single button — it would render a spurious second button with a blank label.

This adds single-button support: an **empty `confirmText` or `cancelText` hides that button**, so a message dialog can show just an OK. This lets consuming apps route their info/acknowledge dialogs through the shared `CrucibleDialogService` instead of keeping a per-app info dialog.

## Changes

- **`crucible-confirm-dialog.component.html`** — guard each action button with `@if` on its label; an empty label hides the button.
- **`crucible-confirm-options.ts`** — document the empty-string convention on `confirmText`/`cancelText`.
- **specs** — add regression coverage for confirm-only and cancel-only (single-button) modes.
- **README** — document single-button (message) dialogs.

The service's per-field `??` defaults already pass an explicit `''` through unchanged (only `null`/`undefined` trigger the fallback), so `CrucibleDialogService` needs no change and existing two-button callers are unaffected.

## Test plan

- [x] `ng test crucible-common --no-watch` — all specs pass (incl. the 2 new single-button specs)
- [x] `ng build crucible-common` — builds clean
- [ ] Confirm a two-button dialog (both labels set) still renders both buttons, cancel-left/confirm-right
- [ ] Confirm `cancelText: ''` renders a single OK button; `confirmText: ''` renders a single dismiss button

## Context

First consumer is Caster.Ui (PR cmu-sei/Caster.Ui#666), which is migrating its per-app confirm dialogs to this shared service. Caster has 11 acknowledge-only info dialogs that need this. That PR will be updated to depend on the published version once this merges.