### PR TITLE
Avoid native title collision in crucible dialog

### DIFF
--- a/projects/@crucible-common/src/lib/crucible-dialog/README.md
+++ b/projects/@crucible-common/src/lib/crucible-dialog/README.md
@@ -70,7 +70,7 @@ this.crucibleDialog.confirm({ title: 'Cannot Delete', message: '…', confirmTex
 
 ```html
 <crucible-dialog
-  title="Edit Directory"
+  dialogTitle="Edit Directory"
   [form]="form"
   submitLabel="Save"
   [submitDisabled]="!form.valid || !form.dirty"
@@ -110,7 +110,9 @@ Enter-to-submit** — convert to a reactive `FormGroup` + `[form]` if you need i
 
 ## Custom title (icon / markup)
 
-`title` is a plain string. When the header needs markup (e.g. an inline icon
+`dialogTitle` is a plain string and is preferred over the deprecated `title`
+input, which overlaps with the native HTML `title` attribute and can create
+unwanted browser tooltips. When the header needs markup (e.g. an inline icon
 button), project `[crucibleDialogTitle]` instead — it renders inside the
 `<h2 mat-dialog-title>`:
 
@@ -124,7 +126,8 @@ button), project `[crucibleDialogTitle]` instead — it renders inside the
 </crucible-dialog>
 ```
 
-Set **either** `title` or a projected `[crucibleDialogTitle]` (the latter wins).
+Set **either** `dialogTitle` or a projected `[crucibleDialogTitle]` (the latter
+wins).
 
 ## Dismissal behavior (baked in — §7)
 

--- a/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.html
+++ b/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.html
@@ -6,7 +6,7 @@
     <!-- Custom header (e.g. title text + an icon button). Projected once. -->
     <ng-content select="[crucibleDialogTitle]"></ng-content>
   } @else {
-    {{ resolvedTitle }}
+    {{ dialogTitle() }}
   }
 </h2>
 

--- a/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.html
+++ b/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.html
@@ -6,7 +6,7 @@
     <!-- Custom header (e.g. title text + an icon button). Projected once. -->
     <ng-content select="[crucibleDialogTitle]"></ng-content>
   } @else {
-    {{ title() }}
+    {{ resolvedTitle }}
   }
 </h2>
 

--- a/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.spec.ts
+++ b/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.spec.ts
@@ -29,7 +29,7 @@ class MatDialogRefStub {
 @Component({
     template: `
     <crucible-dialog
-      [title]="title"
+      [dialogTitle]="title"
       [form]="form"
       [submitLabel]="submitLabel"
       [submitDisabled]="submitDisabled()"
@@ -73,7 +73,7 @@ class FormHostComponent {
 @Component({
     template: `
     <crucible-dialog
-      [title]="title"
+      [dialogTitle]="title"
       [submitDisabled]="submitDisabled()"
       (submit)="onSubmit()"
       (cancel)="onCancel()"
@@ -106,7 +106,7 @@ class ContentHostComponent {
     // projected [crucibleDialogActions] block. This is the combination that
     // regressed when the wrapper duplicated <ng-content> across @if branches.
     template: `
-    <crucible-dialog [title]="title" [hideDefaultActions]="true">
+    <crucible-dialog [dialogTitle]="title" [hideDefaultActions]="true">
       <p crucibleDialogContent id="projected-message">{{ message }}</p>
       <ng-container crucibleDialogActions>
         <button id="proj-no" matButton="outlined" type="button">No</button>
@@ -123,7 +123,7 @@ class ProjectedActionsHostComponent {
 
 @Component({
     // A custom title/header (e.g. an icon button alongside the title text) projected
-    // via [crucibleDialogTitle] instead of the plain `title` string input.
+    // via [crucibleDialogTitle] instead of the plain `dialogTitle` string input.
     template: `
     <crucible-dialog>
       <div crucibleDialogTitle>
@@ -136,6 +136,19 @@ class ProjectedActionsHostComponent {
     imports: [...CRUCIBLE_DIALOG_IMPORTS],
 })
 class ProjectedTitleHostComponent {
+}
+
+@Component({
+    // Deprecated compatibility path: static title="..." should still feed the
+    // dialog title but must not leave a native host title tooltip behind.
+    template: `
+    <crucible-dialog title="Legacy Static Title" [hideDefaultActions]="true">
+      <p crucibleDialogContent>Body</p>
+    </crucible-dialog>
+  `,
+    imports: [...CRUCIBLE_DIALOG_IMPORTS],
+})
+class LegacyStaticTitleHostComponent {
 }
 
 describe('CrucibleDialogComponent', () => {
@@ -155,6 +168,7 @@ describe('CrucibleDialogComponent', () => {
                 ContentHostComponent,
                 ProjectedActionsHostComponent,
                 ProjectedTitleHostComponent,
+                LegacyStaticTitleHostComponent,
             ],
             providers: [{ provide: MatDialogRef, useValue: dialogRef }],
         }).compileComponents();
@@ -179,6 +193,11 @@ describe('CrucibleDialogComponent', () => {
             expect(host.dialog).toBeTruthy();
             const h2: HTMLElement = fixture.nativeElement.querySelector('h2[mat-dialog-title]');
             expect(h2.textContent?.trim()).toBe('Edit Directory');
+        });
+
+        it('does not set a native title attribute on the crucible-dialog host', () => {
+            const dialogHost: HTMLElement = fixture.nativeElement.querySelector('crucible-dialog');
+            expect(dialogHost.hasAttribute('title')).toBe(false);
         });
 
         it('projects content into mat-dialog-content', () => {
@@ -372,7 +391,7 @@ describe('CrucibleDialogComponent', () => {
     });
 
     // A projected [crucibleDialogTitle] renders custom title markup (e.g. an icon
-    // button) inside the h2 mat-dialog-title, instead of the plain `title` string.
+    // button) inside the h2 mat-dialog-title, instead of the plain `dialogTitle` string.
     describe('projected custom title', () => {
         let fixture: ComponentFixture<ProjectedTitleHostComponent>;
 
@@ -386,6 +405,25 @@ describe('CrucibleDialogComponent', () => {
             expect(h2.querySelector('#custom-title-text')?.textContent).toContain('Edit Organization');
             // the icon affordance the string-only title could not express
             expect(h2.querySelector('#title-icon')).toBeTruthy();
+        });
+    });
+
+    describe('deprecated title input compatibility', () => {
+        let fixture: ComponentFixture<LegacyStaticTitleHostComponent>;
+
+        beforeEach(async () => {
+            fixture = TestBed.createComponent(LegacyStaticTitleHostComponent);
+            await fixture.whenStable();
+        });
+
+        it('renders a static title attribute as the dialog title', () => {
+            const h2: HTMLElement = fixture.nativeElement.querySelector('h2[mat-dialog-title]');
+            expect(h2.textContent?.trim()).toBe('Legacy Static Title');
+        });
+
+        it('removes the native host title attribute to prevent browser tooltips', () => {
+            const dialogHost: HTMLElement = fixture.nativeElement.querySelector('crucible-dialog');
+            expect(dialogHost.hasAttribute('title')).toBe(false);
         });
     });
 });

--- a/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.spec.ts
+++ b/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.spec.ts
@@ -139,8 +139,8 @@ class ProjectedTitleHostComponent {
 }
 
 @Component({
-    // Deprecated compatibility path: static title="..." should still feed the
-    // dialog title but must not leave a native host title tooltip behind.
+    // Guard against reintroducing a native host title tooltip. The plain `title`
+    // attribute is intentionally not a component input; use `dialogTitle`.
     template: `
     <crucible-dialog title="Legacy Static Title" [hideDefaultActions]="true">
       <p crucibleDialogContent>Body</p>
@@ -148,7 +148,7 @@ class ProjectedTitleHostComponent {
   `,
     imports: [...CRUCIBLE_DIALOG_IMPORTS],
 })
-class LegacyStaticTitleHostComponent {
+class NativeTitleAttributeHostComponent {
 }
 
 describe('CrucibleDialogComponent', () => {
@@ -168,7 +168,7 @@ describe('CrucibleDialogComponent', () => {
                 ContentHostComponent,
                 ProjectedActionsHostComponent,
                 ProjectedTitleHostComponent,
-                LegacyStaticTitleHostComponent,
+                NativeTitleAttributeHostComponent,
             ],
             providers: [{ provide: MatDialogRef, useValue: dialogRef }],
         }).compileComponents();
@@ -408,17 +408,17 @@ describe('CrucibleDialogComponent', () => {
         });
     });
 
-    describe('deprecated title input compatibility', () => {
-        let fixture: ComponentFixture<LegacyStaticTitleHostComponent>;
+    describe('native title attribute guard', () => {
+        let fixture: ComponentFixture<NativeTitleAttributeHostComponent>;
 
         beforeEach(async () => {
-            fixture = TestBed.createComponent(LegacyStaticTitleHostComponent);
+            fixture = TestBed.createComponent(NativeTitleAttributeHostComponent);
             await fixture.whenStable();
         });
 
-        it('renders a static title attribute as the dialog title', () => {
+        it('does not render a native title attribute as the dialog title', () => {
             const h2: HTMLElement = fixture.nativeElement.querySelector('h2[mat-dialog-title]');
-            expect(h2.textContent?.trim()).toBe('Legacy Static Title');
+            expect(h2.textContent?.trim()).toBe('');
         });
 
         it('removes the native host title attribute to prevent browser tooltips', () => {

--- a/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.ts
+++ b/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.ts
@@ -36,6 +36,9 @@ import { CrucibleDialogTitleDirective } from '../../directives/crucible-dialog-t
   selector: 'crucible-dialog',
   templateUrl: './crucible-dialog.component.html',
   styleUrls: ['./crucible-dialog.component.scss'],
+  host: {
+    '[attr.title]': 'null',
+  },
   imports: [
     CommonModule,
     ReactiveFormsModule,
@@ -49,7 +52,12 @@ export class CrucibleDialogComponent {
   /**
    * Dialog title rendered as <h2 mat-dialog-title>; provides the accessible name.
    * Optional only when a `[crucibleDialogTitle]` header is projected instead (e.g.
-   * a title with an icon button). One of `title` or a projected title must be set.
+   * a title with an icon button). One of `dialogTitle` or a projected title must be set.
+   */
+  dialogTitle = input<string>('');
+  /**
+   * @deprecated Use `dialogTitle`. The `title` input name overlaps with the native
+   * HTML title attribute and can create unwanted browser tooltips with static usage.
    */
   title = input<string>('');
   /** In-flight flag. Disables the primary, shows a spinner, swaps to loadingLabel, guards close. */
@@ -90,7 +98,7 @@ export class CrucibleDialogComponent {
   @ContentChild(CrucibleDialogActionsDirective)
   projectedActions?: CrucibleDialogActionsDirective;
 
-  /** Auto-detected custom title; presence renders the projected header instead of the `title` string. */
+  /** Auto-detected custom title; presence renders the projected header instead of the `dialogTitle` string. */
   @ContentChild(CrucibleDialogTitleDirective)
   projectedTitle?: CrucibleDialogTitleDirective;
 
@@ -123,6 +131,11 @@ export class CrucibleDialogComponent {
   /** Effective disabled state of the primary button. */
   get primaryDisabled(): boolean {
     return this.submitDisabled() || this.loading();
+  }
+
+  /** Preferred dialog title, falling back to the deprecated native-name alias. */
+  get resolvedTitle(): string {
+    return this.dialogTitle() || this.title();
   }
 
   /** True when the default Cancel/Submit pair should render. */

--- a/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.ts
+++ b/projects/@crucible-common/src/lib/crucible-dialog/components/crucible-dialog/crucible-dialog.component.ts
@@ -55,11 +55,6 @@ export class CrucibleDialogComponent {
    * a title with an icon button). One of `dialogTitle` or a projected title must be set.
    */
   dialogTitle = input<string>('');
-  /**
-   * @deprecated Use `dialogTitle`. The `title` input name overlaps with the native
-   * HTML title attribute and can create unwanted browser tooltips with static usage.
-   */
-  title = input<string>('');
   /** In-flight flag. Disables the primary, shows a spinner, swaps to loadingLabel, guards close. */
   loading = input(false, { transform: booleanAttribute });
   /** Server/validation error; rendered as role=alert inside content when non-empty. */
@@ -131,11 +126,6 @@ export class CrucibleDialogComponent {
   /** Effective disabled state of the primary button. */
   get primaryDisabled(): boolean {
     return this.submitDisabled() || this.loading();
-  }
-
-  /** Preferred dialog title, falling back to the deprecated native-name alias. */
-  get resolvedTitle(): string {
-    return this.dialogTitle() || this.title();
   }
 
   /** True when the default Cancel/Submit pair should render. */

--- a/projects/@crucible-common/src/lib/crucible-dialog/directives/crucible-dialog-title.directive.ts
+++ b/projects/@crucible-common/src/lib/crucible-dialog/directives/crucible-dialog-title.directive.ts
@@ -6,8 +6,9 @@ import { Directive } from '@angular/core';
 /**
  * Optional projection marker for a custom dialog title/header (e.g. a title with
  * an icon or an inline action button). When present, the wrapper projects it
- * inside the <h2 mat-dialog-title> instead of rendering the plain `title` string.
- * Most dialogs just set the `title` input; use this only when the title needs markup.
+ * inside the <h2 mat-dialog-title> instead of rendering the plain `dialogTitle`
+ * string. Most dialogs just set the `dialogTitle` input; use this only when the
+ * title needs markup.
  */
 @Directive({
   selector: '[crucibleDialogTitle]',

--- a/projects/cwd-common-app/src/app/dialog-demo/demo-form-dialog.component.ts
+++ b/projects/cwd-common-app/src/app/dialog-demo/demo-form-dialog.component.ts
@@ -30,7 +30,7 @@ import { CRUCIBLE_DIALOG_IMPORTS } from 'projects/@crucible-common/src/public-ap
   ],
   template: `
     <crucible-dialog
-      [title]="'Create New Project?'"
+      [dialogTitle]="'Create New Project?'"
       [form]="form"
       submitLabel="Save"
       cancelLabel="Cancel"


### PR DESCRIPTION
## Summary
- Replace the dialog string-title API with `dialogTitle` so consumers do not overload the native HTML `title` attribute.
- Remove the deprecated `title` input fallback to keep the component API clean and make accidental `title="..."` usage visible during migration.
- Keep a defensive host binding that clears the native `title` attribute so accidental static attributes do not create browser tooltips.
- Update docs, demo usage, and unit coverage for the new API and native-title guard.

## Implementation Notes
- `CrucibleDialogComponent` now renders `dialogTitle()` directly in the `mat-dialog-title` header when no custom `[crucibleDialogTitle]` projection is supplied.
- Plain `title="..."` is intentionally not treated as a dialog title anymore. The regression test verifies it does not render as header text and does not remain on the host element.
- Consumers should migrate `<crucible-dialog [title]="...">` or `<crucible-dialog title="...">` to `[dialogTitle]="..."` or `dialogTitle="..."`.

## Testing
- `npx ng build crucible-common`
- `npx ng test crucible-common --watch=false`